### PR TITLE
Issue #2: Download the video and rename it with its title.

### DIFF
--- a/src/backend/fetch.rs
+++ b/src/backend/fetch.rs
@@ -21,9 +21,9 @@ pub mod api {
     }
 
     ///Receives a url-compatible &string and returns a tuple with link keys and an object with those links
-    pub async fn fetch_video(
+    pub async fn fetch_video_info(
         video_url: &str,
-    ) -> Result<(Vec<String>, serde_json::Value, Vec<String>, String)> {
+    ) -> Result<(Vec<String>, serde_json::Value, Vec<String>, String, String)> {
         let mut available_q: Vec<String> = Vec::new(); // This vector stores all the qualities available fo the video to download
         println!("{}", "Fetching videos".blue());
         // Base Url to make the request.
@@ -66,14 +66,21 @@ pub mod api {
             );
         }
         let video_id = response_data["vid"].as_str().unwrap().to_string();
-        Ok((response_data_keys, response_data, available_q, video_id))
+        let video_title = response_data["title"].as_str().unwrap().to_string();
+        Ok((
+            response_data_keys,
+            response_data,
+            available_q,
+            video_id,
+            video_title,
+        ))
     }
 
     pub fn get_links_by_quality(
         quality: &str,
         links_tuple: (Vec<String>, serde_json::Value),
     ) -> String {
-        let quality = Value::String(quality.to_owned()); // Convert quality &str type into a a Value::String() type to use later.
+        //let quality = Value::String(quality.to_owned()); // Convert quality &str type into a a Value::String() type to use later.
         let (keys, links_obj) = links_tuple; // Destructuring th tuple.
         let mut links: Vec<&Map<std::string::String, Value>> = Vec::new(); // Creates a new vector
 
@@ -82,7 +89,7 @@ pub mod api {
         }
         let mut video_key = String::new();
         for (i, _) in links.iter().enumerate() {
-            if quality == links[i]["q"] {
+            if quality.to_owned() == links[i]["q"].as_str().unwrap() {
                 video_key = links[i]["k"].as_str().unwrap().to_string();
             } else {
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod backend;
 use backend::{fetch::api, get_directory};
 use clap::Parser;
-// CLI 
+// CLI
 #[derive(Debug, Parser)]
 #[clap(
     author = "Author: github.com/alejandro0619",
@@ -23,15 +23,19 @@ struct Args {
 async fn main() {
     let args = Args::parse();
     // Search and create a directory to donwload videos.
-    let directory = get_directory::create_vid_dir().unwrap(); 
-    let (keys, links, _available_q, video_id) =
-        api::fetch_video(&args.link) 
-            .await
-            .unwrap();
+    let directory = get_directory::create_vid_dir().unwrap();
+    let (keys, links, _available_q, video_id, video_title) =
+        api::fetch_video_info(&args.link).await.unwrap();
+    // Remove / if there's any
+    let video_title = video_title.replace("/", "");
     // Get the video key depeding on the quality entered by the user
-    let video_key: String = api::get_links_by_quality(&args.quality, (keys, links)); 
+    let video_key: String = api::get_links_by_quality("720p", (keys, links));
+    println!("{}", video_title);
     let download_link = api::get_download_link(video_id, video_key).await.unwrap();
-    api::download_video(download_link, directory.join("test4.mp4"))
-        .await
-        .unwrap(); // Downloads the video
+    api::download_video(
+        download_link,
+        directory.join(&format!("{}.mp4", video_title)),
+    )
+    .await
+    .unwrap(); // Downloads the video
 }


### PR DESCRIPTION
This PR closes #2 
Now the videos can be downloaded saved using its title's name.
Note: Every "/" character will be removed in order to avoid errors because of the filesystem